### PR TITLE
Fixing Teldrassil Burned event requirement to check correctly for des…

### DIFF
--- a/events/Flavour - World Tree.txt
+++ b/events/Flavour - World Tree.txt
@@ -93,7 +93,7 @@ country_event = {
 		has_country_flag = burning_teldrassil_timer
         NOT = {
             any_country = {
-                has_country_modifier = destroyer_of_nordrassil
+                has_country_modifier = destroyer_of_teldrassil
             }
         }
 	}


### PR DESCRIPTION
Replacing one line in Flavour - World Tree.txt to fix modifier check, event fires correctly now after 10 years from taking decision to burn. Previously was failing to execute if Nordrassil has been burned before.