### PR TITLE
Quel'thalas mission bypass

### DIFF
--- a/missions/WWU - Quel'thalas.txt
+++ b/missions/WWU - Quel'thalas.txt
@@ -17,9 +17,16 @@ wwu_quelthalas_column_4 = {
 		required_missions = {  } 
         
 		trigger = {
-            has_casus_belli_against = A58
-            army_size_percentage = 1.0
-            manpower_percentage = 1.0
+            OR = {
+                AND = {
+                    has_casus_belli_against = A58
+                    army_size_percentage = 1.0
+                    manpower_percentage = 1.0
+                }
+                NOT = {
+                    exists = A58
+                }
+            }
 		}
 		effect = { 
             add_mil_power = 100


### PR DESCRIPTION
Bypass prepare for troll invasion mission if Amani no longer exists,
otherwise a player would need to resurect Amani first.