### PR TITLE
Trigger startup configuration event consistently

### DIFF
--- a/common/on_actions/00_on_actions.txt
+++ b/common/on_actions/00_on_actions.txt
@@ -34,7 +34,6 @@ on_startup = {
     events = {
         wwu_setup.1    # Global
         wwu_setup.2    # Country
-        wwu_setup.3    # Configuration
 		wwu_setup.4    # Debug
         wwu_loa.1      # Influence of the Loa
 		wwu_dragon_isles.1 # Dragon Shrines

--- a/events/System - Setup.txt
+++ b/events/System - Setup.txt
@@ -263,6 +263,7 @@ country_event = {
                 duration = -1
             }
         }
+        country_event = { id = wwu_setup.3 days = 1 }
     }
     
     option = {
@@ -273,6 +274,9 @@ country_event = {
 #---------------------------------------
 # Configuration
 #---------------------------------------
+# This event has to be triggered after the flags in `wwu_setup.1` flags
+# has been properly set, otherwise certain flags might not be set
+# correctly when triggering this event, such as `executor`
 country_event = {
 	id = wwu_setup.3
 	title = wwu_setup.3.title
@@ -283,8 +287,8 @@ country_event = {
 
     trigger = {
         NOT = { has_global_flag = completed_wwu_configuration }
-        has_country_flag = host_player
         ai = no
+        tag = event_target:executor
     }
 
     immediate = {


### PR DESCRIPTION
Before this commit, the startup event `wwu_setup.3`, which currently
configures the diplomatic options, would not trigger at start. Only when
the game was reloaded or somehow reset this event would trigger.

The cause of this error seems to be the order the country flags are set
and read. `on_startup` did set the country flag `host_player`, but the
values are not read properly if the event that requires this flag is
also fired at the same time.

Instead of using `host_player` as the flag for determining the host, the
event now uses `event_target:executor`. And by also triggering both
`wwu_setup.1` (which configures the world) and `wwu_setup.3` in
sequence, `wwu_setup.3` now always triggers consistently 1 day after game
start.