### PR TITLE
Fix local setup of `cspell`

### DIFF
--- a/# Development/tools/spell-checking/cspell_docker_setup.sh
+++ b/# Development/tools/spell-checking/cspell_docker_setup.sh
@@ -1,4 +1,18 @@
+echo "Install python and wget. wget is required for `n`"
 apt update --assume-yes || exit $?
-apt install python3 --assume-yes || exit $?
+apt install python3 wget --assume-yes || exit $?
+
+echo "Install latest and upgrade to latest npm version"
 apt install npm --assume-yes || exit $?
+npm install --global npm@latest || exit $?
+
+echo "Upgrade node to latest version"
+npm cache verify || exit $?
+npm install --global n || exit $?
+n stable || exit $?
+hash -r || exit $?
+
+echo "Install cspell"
 npm install --global cspell || exit $?
+
+echo "Setup completed successfully"

--- a/# Development/tools/spell-checking/readme.md
+++ b/# Development/tools/spell-checking/readme.md
@@ -11,8 +11,8 @@
 To setup your environment to spell check, run the following:
 
 ```shell
-docker run --volume <path\to\repo>:/host_dir --tty --interactive ubuntu:22.04
-cd /host_dir && ./"# Development"/tools/spell-checking/cspell_docker_setup.sh
+docker run --volume <path\to\repo>:/host_dir --tty --interactive --rm --workdir /host_dir ubuntu:22.04
+./"# Development"/tools/spell-checking/cspell_docker_setup.sh
 ```
 
 Note `<C:\path\to\repo\>` should be replaced by the path to the root of the repository,


### PR DESCRIPTION
The old setup triggered an error message seen at the end of this commit
message, which indicates that `cspell` requires an updated version of
`node` to function. This commit solves that problem using `n` setup
`node` to be the latest stable version.

This commit also adds some flags to the setup of a docker container, so
that the container is deleted on exit and working directory is already
set at start.

Error message:

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'cspell@6.0.0',
npm WARN EBADENGINE   required: { node: '>=14' },
npm WARN EBADENGINE   current: { node: 'v12.22.9', npm: '8.5.1' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@cspell/cspell-pipe@6.0.0',
npm WARN EBADENGINE   required: { node: '>=14' },
npm WARN EBADENGINE   current: { node: 'v12.22.9', npm: '8.5.1' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'cspell-gitignore@6.0.0',
npm WARN EBADENGINE   required: { node: '>=14' },
npm WARN EBADENGINE   current: { node: 'v12.22.9', npm: '8.5.1' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'cspell-glob@6.0.0',
npm WARN EBADENGINE   required: { node: '>=14' },
npm WARN EBADENGINE   current: { node: 'v12.22.9', npm: '8.5.1' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'cspell-lib@6.0.0',
npm WARN EBADENGINE   required: { node: '>=14' },
npm WARN EBADENGINE   current: { node: 'v12.22.9', npm: '8.5.1' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@cspell/cspell-bundled-dicts@6.0.0',
npm WARN EBADENGINE   required: { node: '>=14' },
npm WARN EBADENGINE   current: { node: 'v12.22.9', npm: '8.5.1' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@cspell/cspell-types@6.0.0',
npm WARN EBADENGINE   required: { node: '>=14' },
npm WARN EBADENGINE   current: { node: 'v12.22.9', npm: '8.5.1' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'cspell-io@6.0.0',
npm WARN EBADENGINE   required: { node: '>=14' },
npm WARN EBADENGINE   current: { node: 'v12.22.9', npm: '8.5.1' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'cspell-trie-lib@6.0.0',
npm WARN EBADENGINE   required: { node: '>=14' },
npm WARN EBADENGINE   current: { node: 'v12.22.9', npm: '8.5.1' }
npm WARN EBADENGINE }
```