### PR TITLE
Deal with recently added vocabulary

### DIFF
--- a/# Development/tools/spell-checking/dictionaries/eu4-terminology.txt
+++ b/# Development/tools/spell-checking/dictionaries/eu4-terminology.txt
@@ -2,3 +2,4 @@ Crownland
 Forcelimit
 Organiser
 Recruitmaster
+Formables

--- a/# Development/tools/spell-checking/dictionaries/warcraft-cultures.txt
+++ b/# Development/tools/spell-checking/dictionaries/warcraft-cultures.txt
@@ -10,3 +10,5 @@ lordaerons
 orks
 Moroc
 Moroci
+Rancoran
+Niskaran

--- a/# Development/tools/spell-checking/dictionaries/warcraft-places.txt
+++ b/# Development/tools/spell-checking/dictionaries/warcraft-places.txt
@@ -7,3 +7,8 @@ Northrend
 Stormwind
 Tirisfal
 Nathreza
+Mardum
+Xoroth
+Rancora
+Niskara
+Nihilam

--- a/common/event_modifiers/WWU - Mission - Sentinels.txt
+++ b/common/event_modifiers/WWU - Mission - Sentinels.txt
@@ -1,7 +1,7 @@
 #---------------------------------------
 # Modifiers
 #---------------------------------------
-mission_ordilaran_artifacts = {
+mission_ordil_aran_artifacts = {
     global_tax_modifier = 0.05
 }
 

--- a/localisation/decisions/WWU_decisions_l_english.yml
+++ b/localisation/decisions/WWU_decisions_l_english.yml
@@ -1825,7 +1825,7 @@
  # Form Fel Hammer
  #-----------------------------------------------
  form_fel_hammer_title: "Form Fel Hammer"
- form_fel_hammer_desc: "In one of our assailts in the demonworld of Mardum we acquired this great fortress that will become symbol of our fight against the demons!"
+ form_fel_hammer_desc: "In one of our assaults in the demon world of Mardum we acquired this great fortress that will become symbol of our fight against the demons!"
  
  #-----------------------------------------------
  # Form Demonic Formables

--- a/localisation/missions/WWU_mission_sentinels_l_english.yml
+++ b/localisation/missions/WWU_mission_sentinels_l_english.yml
@@ -7,53 +7,53 @@
  wwu_sentinels_column_5: ""
  
  wwu_plant_the_seeds_of_teldrassil_title: "Plant the Seeds of Teldrassil"
- wwu_plant_the_seeds_of_teldrassil_desv: ""
+ wwu_plant_the_seeds_of_teldrassil_desc: ""
  
  NIGHT_ELF_AMBITION_TT: "Unlocks the ability to §YPlant Teldrassil§!."
  night_elf_ambition: "May Plant Teldrassil"
  
  wwu_populate_teldrassil_title: "Populate Teldrassil"
- wwu_populate_teldrassil_desv: ""
+ wwu_populate_teldrassil_desc: ""
  
  wwu_oust_thistlefur_title: "Oust Thistlefur"
- wwu_oust_thistlefur_desv: ""
+ wwu_oust_thistlefur_desc: ""
  
  wwu_secure_the_northern_passage_title: "Secure the Northern Passage"
- wwu_secure_the_northern_passage_desv: ""
+ wwu_secure_the_northern_passage_desc: ""
  
  wwu_cull_the_beasts_title: "Cull the Beasts"
- wwu_cull_the_beasts_desv: ""
+ wwu_cull_the_beasts_desc: ""
  
  wwu_purge_fel_influence_title: "Purge Fel Influence"
- wwu_purge_fel_influence_desv: ""
+ wwu_purge_fel_influence_desc: ""
  
  wwu_unity_with_cenarion_circle_title: "Unity with the Cenarion Circle"
- wwu_unity_with_cenarion_circle_desv: ""
+ wwu_unity_with_cenarion_circle_desc: ""
  
  wwu_push_into_the_felwood_title: "Push into the Felwood"
- wwu_push_into_the_felwood_desv: ""
+ wwu_push_into_the_felwood_desc: ""
 
  wwu_exterminate_the_northern_satyrs_title: "Exterminate the Northern Satyrs"
- wwu_exterminate_the_northern_satyrs_desv: ""
+ wwu_exterminate_the_northern_satyrs_desc: ""
  
  wwu_secure_western_ashenvale_title: "Secure Western Ashenvale"
- wwu_secure_western_ashenvale_desv: ""
+ wwu_secure_western_ashenvale_desc: ""
  
  wwu_purge_satyr_threat_title: "Purge Satyr Threat"
- wwu_purge_satyr_threat_desv: ""
+ wwu_purge_satyr_threat_desc: ""
  
  wwu_enter_the_zoram_title: "Enter the Zoram"
- wwu_enter_the_zoram_desv: ""
+ wwu_enter_the_zoram_desc: ""
  
  wwu_push_into_azshara_title: "Push into Azshara"
- wwu_push_into_azshara_desv: ""
+ wwu_push_into_azshara_desc: ""
  
  wwu_exterminate_the_eastern_satyrs_title: "Exterminate the Eastern Satyrs"
- wwu_exterminate_the_eastern_satyrs_desv: ""
+ wwu_exterminate_the_eastern_satyrs_desc: ""
  
  # --- Modifiers ---
- mission_ordilaran_artifacts: "Ordil'aran Artifacts"
- desc_mission_ordilaran_artifacts: ""
+ mission_ordil_aran_artifacts: "Ordil'aran Artifacts"
+ desc_mission_ordil_aran_artifacts: ""
  
  mission_northern_passage_cleared: "Northern Passage Cleared"
  desc_mission_northern_passage_cleared: ""

--- a/missions/WWU - Sentinels.txt
+++ b/missions/WWU - Sentinels.txt
@@ -95,7 +95,7 @@ wwu_sentinels_column_2 = {
         
 		effect = {
 			add_country_modifier = {
-                name = mission_ordilaran_artifacts
+                name = mission_ordil_aran_artifacts
                 duration = -1
             }
 		}


### PR DESCRIPTION
This commit simply cleans up some minor vocabulary that were added by
commits 1f5db5940a482aa5acaedee65af9ac618c5e08f8 and
97d6cc7256323a0c45a69375c5de78fa73d8df84.