### PR TITLE
Fix localization for `naval` and `piracy` idea groups

### DIFF
--- a/common/ideas/WWU - Ideagroup - DIP.txt
+++ b/common/ideas/WWU - Ideagroup - DIP.txt
@@ -577,32 +577,32 @@ wwu_naval_ideas = {
         naval_maintenance_modifier = -0.1
     }
     # Born of the Sea
-    wwu_naval_bombardment_ideas_1 = {
+    wwu_naval_ideas_1 = {
         navy_tradition = 1.0
     }
     # Expert Bombardment
-    wwu_naval_bombardment_ideas_2 = {
+    wwu_naval_ideas_2 = {
         heavy_ship_power = 0.05
         galley_power = 0.05
     }
     # Efficient Shipyards
-    wwu_naval_bombardment_ideas_3 = {
+    wwu_naval_ideas_3 = {
         global_ship_cost = -0.25
     }
     # Grand Armarda
-    wwu_naval_bombardment_ideas_4 = {
+    wwu_naval_ideas_4 = {
         naval_forcelimit_modifier = 0.15
     }
     # Man the Decks
-    wwu_naval_bombardment_ideas_5 = {
+    wwu_naval_ideas_5 = {
         global_sailors_modifier = 0.25
     }
     # Impenetrable Hulls
-    wwu_naval_bombardment_ideas_6 = {
+    wwu_naval_ideas_6 = {
         ship_durability = 0.05
     }
     # Oceanic Campaigns
-    wwu_naval_bombardment_ideas_7 = {
+    wwu_naval_ideas_7 = {
         leader_naval_fire = 1
         leader_naval_manuever = 1
     }
@@ -632,32 +632,32 @@ wwu_piracy_ideas = {
     }
     
     # Looted Shipyards
-    wwu_piracy_ideas_ideas_1 = {
+    wwu_piracy_ideas_1 = {
         light_ship_cost = -0.33
     }
     # Commandeered Vessels
-    wwu_piracy_ideas_ideas_2 = {
+    wwu_piracy_ideas_2 = {
         light_ship_power = 0.05
         sunk_ship_morale_hit_recieved = -0.1
     }
     # Pirate Sailors
-    wwu_piracy_ideas_ideas_3 = {
+    wwu_piracy_ideas_3 = {
         global_sailors_modifier = 0.2
     }
     # Horrifying Blockades
-    wwu_piracy_ideas_ideas_4 = {
+    wwu_piracy_ideas_4 = {
         blockade_efficiency = 0.33
     }
     # Infamous Crews
-    wwu_piracy_ideas_ideas_5 = {
+    wwu_piracy_ideas_5 = {
         privateer_efficiency = 0.33
     }
     # Mapped Sea Routes
-    wwu_piracy_ideas_ideas_6 = {
+    wwu_piracy_ideas_6 = {
         global_ship_trade_power = 0.1
     }
     # Embargos
-    wwu_piracy_ideas_ideas_7 = {
+    wwu_piracy_ideas_7 = {
         embargo_efficiency = 0.33
     }
     

--- a/localisation/WWU_ideagroups_l_english.yml
+++ b/localisation/WWU_ideagroups_l_english.yml
@@ -513,36 +513,6 @@
  wwu_subjugation_ideas_7: "Squeeze Them Dry"
  wwu_subjugation_ideas_7_desc: "Provides the following modifiers:"
 
- wwu_naval_bombardment_ideas_1: " "
- wwu_naval_bombardment_ideas_1_desc: " "
- wwu_naval_bombardment_ideas_2: " "
- wwu_naval_bombardment_ideas_2_desc: " "
- wwu_naval_bombardment_ideas_3: " "
- wwu_naval_bombardment_ideas_3_desc: " "
- wwu_naval_bombardment_ideas_4: " "
- wwu_naval_bombardment_ideas_4_desc: " "
- wwu_naval_bombardment_ideas_5: " "
- wwu_naval_bombardment_ideas_5_desc: " "
- wwu_naval_bombardment_ideas_6: " "
- wwu_naval_bombardment_ideas_6_desc: " "
- wwu_naval_bombardment_ideas_7: " "
- wwu_naval_bombardment_ideas_7_desc: " "
-
- wwu_piracy_ideas_ideas_1: " "
- wwu_piracy_ideas_ideas_1_desc: " "
- wwu_piracy_ideas_ideas_2: " "
- wwu_piracy_ideas_ideas_2_desc: " "
- wwu_piracy_ideas_ideas_3: " "
- wwu_piracy_ideas_ideas_3_desc: " "
- wwu_piracy_ideas_ideas_4: " "
- wwu_piracy_ideas_ideas_4_desc: " "
- wwu_piracy_ideas_ideas_5: " "
- wwu_piracy_ideas_ideas_5_desc: " "
- wwu_piracy_ideas_ideas_6: " "
- wwu_piracy_ideas_ideas_6_desc: " "
- wwu_piracy_ideas_ideas_7: " "
- wwu_piracy_ideas_ideas_7_desc: " "
-
 
  #---------------------------------------------------
  # MIL

--- a/localisation/WWU_ideagroups_l_french.yml
+++ b/localisation/WWU_ideagroups_l_french.yml
@@ -513,36 +513,6 @@
  wwu_subjugation_ideas_7: "Squeeze Them Dry"
  wwu_subjugation_ideas_7_desc: "Provides the following modifiers:"
 
- wwu_naval_bombardment_ideas_1: " "
- wwu_naval_bombardment_ideas_1_desc: " "
- wwu_naval_bombardment_ideas_2: " "
- wwu_naval_bombardment_ideas_2_desc: " "
- wwu_naval_bombardment_ideas_3: " "
- wwu_naval_bombardment_ideas_3_desc: " "
- wwu_naval_bombardment_ideas_4: " "
- wwu_naval_bombardment_ideas_4_desc: " "
- wwu_naval_bombardment_ideas_5: " "
- wwu_naval_bombardment_ideas_5_desc: " "
- wwu_naval_bombardment_ideas_6: " "
- wwu_naval_bombardment_ideas_6_desc: " "
- wwu_naval_bombardment_ideas_7: " "
- wwu_naval_bombardment_ideas_7_desc: " "
-
- wwu_piracy_ideas_ideas_1: " "
- wwu_piracy_ideas_ideas_1_desc: " "
- wwu_piracy_ideas_ideas_2: " "
- wwu_piracy_ideas_ideas_2_desc: " "
- wwu_piracy_ideas_ideas_3: " "
- wwu_piracy_ideas_ideas_3_desc: " "
- wwu_piracy_ideas_ideas_4: " "
- wwu_piracy_ideas_ideas_4_desc: " "
- wwu_piracy_ideas_ideas_5: " "
- wwu_piracy_ideas_ideas_5_desc: " "
- wwu_piracy_ideas_ideas_6: " "
- wwu_piracy_ideas_ideas_6_desc: " "
- wwu_piracy_ideas_ideas_7: " "
- wwu_piracy_ideas_ideas_7_desc: " "
-
 
  #---------------------------------------------------
  # MIL

--- a/localisation/WWU_ideagroups_l_german.yml
+++ b/localisation/WWU_ideagroups_l_german.yml
@@ -513,36 +513,6 @@
  wwu_subjugation_ideas_7: "Squeeze Them Dry"
  wwu_subjugation_ideas_7_desc: "Provides the following modifiers:"
 
- wwu_naval_bombardment_ideas_1: " "
- wwu_naval_bombardment_ideas_1_desc: " "
- wwu_naval_bombardment_ideas_2: " "
- wwu_naval_bombardment_ideas_2_desc: " "
- wwu_naval_bombardment_ideas_3: " "
- wwu_naval_bombardment_ideas_3_desc: " "
- wwu_naval_bombardment_ideas_4: " "
- wwu_naval_bombardment_ideas_4_desc: " "
- wwu_naval_bombardment_ideas_5: " "
- wwu_naval_bombardment_ideas_5_desc: " "
- wwu_naval_bombardment_ideas_6: " "
- wwu_naval_bombardment_ideas_6_desc: " "
- wwu_naval_bombardment_ideas_7: " "
- wwu_naval_bombardment_ideas_7_desc: " "
-
- wwu_piracy_ideas_ideas_1: " "
- wwu_piracy_ideas_ideas_1_desc: " "
- wwu_piracy_ideas_ideas_2: " "
- wwu_piracy_ideas_ideas_2_desc: " "
- wwu_piracy_ideas_ideas_3: " "
- wwu_piracy_ideas_ideas_3_desc: " "
- wwu_piracy_ideas_ideas_4: " "
- wwu_piracy_ideas_ideas_4_desc: " "
- wwu_piracy_ideas_ideas_5: " "
- wwu_piracy_ideas_ideas_5_desc: " "
- wwu_piracy_ideas_ideas_6: " "
- wwu_piracy_ideas_ideas_6_desc: " "
- wwu_piracy_ideas_ideas_7: " "
- wwu_piracy_ideas_ideas_7_desc: " "
-
 
  #---------------------------------------------------
  # MIL

--- a/localisation/WWU_ideagroups_l_spanish.yml
+++ b/localisation/WWU_ideagroups_l_spanish.yml
@@ -513,36 +513,6 @@
  wwu_subjugation_ideas_7: "Squeeze Them Dry"
  wwu_subjugation_ideas_7_desc: "Provides the following modifiers:"
 
- wwu_naval_bombardment_ideas_1: " "
- wwu_naval_bombardment_ideas_1_desc: " "
- wwu_naval_bombardment_ideas_2: " "
- wwu_naval_bombardment_ideas_2_desc: " "
- wwu_naval_bombardment_ideas_3: " "
- wwu_naval_bombardment_ideas_3_desc: " "
- wwu_naval_bombardment_ideas_4: " "
- wwu_naval_bombardment_ideas_4_desc: " "
- wwu_naval_bombardment_ideas_5: " "
- wwu_naval_bombardment_ideas_5_desc: " "
- wwu_naval_bombardment_ideas_6: " "
- wwu_naval_bombardment_ideas_6_desc: " "
- wwu_naval_bombardment_ideas_7: " "
- wwu_naval_bombardment_ideas_7_desc: " "
-
- wwu_piracy_ideas_ideas_1: " "
- wwu_piracy_ideas_ideas_1_desc: " "
- wwu_piracy_ideas_ideas_2: " "
- wwu_piracy_ideas_ideas_2_desc: " "
- wwu_piracy_ideas_ideas_3: " "
- wwu_piracy_ideas_ideas_3_desc: " "
- wwu_piracy_ideas_ideas_4: " "
- wwu_piracy_ideas_ideas_4_desc: " "
- wwu_piracy_ideas_ideas_5: " "
- wwu_piracy_ideas_ideas_5_desc: " "
- wwu_piracy_ideas_ideas_6: " "
- wwu_piracy_ideas_ideas_6_desc: " "
- wwu_piracy_ideas_ideas_7: " "
- wwu_piracy_ideas_ideas_7_desc: " "
-
 
  #---------------------------------------------------
  # MIL


### PR DESCRIPTION
The localization for these groups were missing because they referenced
wrong localization keys.