### PR TITLE
Fix for A34_fall_of_the_draenei mission

### DIFF
--- a/missions/WWU - Shadowmoon.txt
+++ b/missions/WWU - Shadowmoon.txt
@@ -245,27 +245,20 @@ A34_shadowmoon_column_4 = {
                 is_year = 590
             }
             else = {
-                OR = {
-                    AND = {
-                        any_country = {
-                            has_country_modifier = mission_acceptance_of_warlocks
-                            owns = 3765
-                        }
-                        any_country = {
-                            has_country_modifier = mission_acceptance_of_warlocks
-                            owns = 3806
-                        }
-                        any_country = {
-                            has_country_modifier = mission_acceptance_of_warlocks
-                            owns = 3770
-                        }
+                3765 = {
+            	    owner = {
+                        has_country_modifier = mission_acceptance_of_warlocks
                     }
                 }
-                AND = {
-                    has_country_modifier = mission_acceptance_of_warlocks
-                    owns = 3765
-                    owns = 3806
-                    owns = 3770
+                3770 = {
+                    owner = {
+                        has_country_modifier = mission_acceptance_of_warlocks
+                    }
+                }
+                3806 = {
+                    owner = {
+                        has_country_modifier = mission_acceptance_of_warlocks
+                    }
                 }
             }
 		}


### PR DESCRIPTION
Fix trigger for A34_fall_of_the_draenei mission. Now any owner of required provinces, with the country_modifier mission_acceptance_of_warlocks is counted.