### PR TITLE
Theramore ideas after formation

### DIFF
--- a/decisions/Formable - Theremore.txt
+++ b/decisions/Formable - Theremore.txt
@@ -53,7 +53,15 @@ country_decisions = {
             # Switch
 			change_tag = A23
 			change_government = monarchy
+			change_primary_culture = culture_theramorean
 			set_capital = 1456
+            every_owned_province = { 
+                limit = {
+                    area = area_theramore_isle
+                    NOT = { culture = culture_theramorean }
+                }
+                change_culture = culture_theramorean
+            }
             
             # Bonus
             add_formable_bonus = yes


### PR DESCRIPTION
Fix: After formation and picking "New ideas & traditions" Theramore get "Human ideas" instead of "Theramore ideas"